### PR TITLE
Update to automatic switch of resources back from/to HTCondor

### DIFF
--- a/admin/config/autoSwitch/README.md
+++ b/admin/config/autoSwitch/README.md
@@ -16,13 +16,12 @@ A possible path and structure is:
 $ pwd
 /home/condset
 $ ls -la
-total 24
+total 20
 drwxrwxr-x 3 root condset 4096 apr 21 16:39 .
 drwxr-xr-x 8 root root    4096 mar 31 09:48 ..
-drwxr-xr-x 2 root condset 4096 apr 21 16:42 .config
 -rwxrwxr-- 1 root condset 7772 apr 21 16:41 switchHTC.sh
 -rw-r--r-- 1 root condset 1105 apr 21 16:41 switchHTC.sh.log
--rw-rw-r-- 1 root condset    0 apr 21 16:19 switch.me
+-rw-rw-r-- 1 root condset    0 apr 21 16:19 .switch.me
 $ ls -la .config
 total 8
 drwxr-xr-x 2 root condset 4096 apr 21 15:38 .
@@ -40,7 +39,7 @@ $ usermod -aG condset <userName>
 ```
 
 ## The trigger file
-The trigger file is `switch.me`:
+The trigger file is `.switch.me`:
 * if present, then the switch takes place - no matter in which direction, i.e. in order to spare resources (e.g. for direct login) or to make them available to HTCondor;
 * if the file is moved (i.e. named differently), then the switch is inhibited; hence, the resources are not moved.
 
@@ -54,9 +53,9 @@ Renaming the file is the preferred option, such that the correct rights, once pr
 # - path to storing folder
 export CondPath="/home/condset"
 # - alias to trigger all resources into HTCondor
-alias HTCfullRes='mv ${CondPath}/dont.switch.me ${CondPath}/switch.me'
+alias HTCTrigOn='mv ${CondPath}/.dont.switch.me ${CondPath}/.switch.me'
 # - alias to spare resources out of HTCondor
-alias HTCSparRes='mv ${CondPath}/switch.me ${CondPath}/dont.switch.me'
+alias HTCTrigOff='mv ${CondPath}/.switch.me ${CondPath}/.dont.switch.me'
 # - alias to display the resources currently available to HTCondor
 alias HTCStatRes='${CondPath}/switchHTC.sh -Q'
 # - alias to display the status of the trigger

--- a/admin/config/autoSwitch/switchHTC.sh
+++ b/admin/config/autoSwitch/switchHTC.sh
@@ -99,13 +99,15 @@ echoResources(){
 }
 
 generateHTCspareFile(){
-    echo > ${HTCset}/.config/${HTCsparConfigFile} <<EOF
+    echo "call to generateHTCspareFile()"
+    cat > ${HTCset}/${HTCsparConfigFile} <<EOF
 # spare resources
 # - reserve ${HTCSparRAM} GB of RAM
 MEMORY = \$(DETECTED_MEMORY)-${HTCSparRAM}*1024
 # - reserve 20 threads
 NUM_CPUS = \$(NUM_CPUS)-${HTCSparCPUs}
 EOF
+    echo "...done;"
 }
 
 switchResources() {
@@ -121,11 +123,11 @@ switchResources() {
     if ${lSpare} ; then
         ! ${lDebug} || echo "...debug info: generateHTCspareFile()"
         generateHTCspareFile
-        if [ -e ${HTCset}/.config/${HTCsparConfigFile} ] ; then
-            echo "... ${HTCsparConfigFile} present in ${HTCset}/.config: sparing resources of the node from HTCondor..."
+        if [ -e ${HTCset}/${HTCsparConfigFile} ] ; then
+            echo "... ${HTCsparConfigFile} present in ${HTCset}: sparing resources of the node from HTCondor..."
             lSwitch=true
         else
-            echo "...no ${HTCsparConfigFile} in ${HTCset}/.config: aborting switch..."
+            echo "...no ${HTCsparConfigFile} in ${HTCset}: aborting switch..."
         fi
     elif ${lFull} ; then
         if [ -e ${HTCconfig}/${HTCsparConfigFile} ] ; then
@@ -141,8 +143,8 @@ switchResources() {
             echo "...debug info: situation BEFORE switch:"
             echoResources
         fi
-        # ! ${lDebug} || echo "...debug info: condor_off -peaceful -startd"
-        # condor_off -peaceful -startd
+        ! ${lDebug} || echo "...debug info: condor_off -peaceful -startd"
+        condor_off -peaceful -startd
         if ${lSpare} ; then
             ! ${lDebug} || echo "...debug info: mv ${HTCset}/${HTCsparConfigFile} ${HTCconfig}"
             mv ${HTCset}/${HTCsparConfigFile} ${HTCconfig}
@@ -150,12 +152,12 @@ switchResources() {
             ! ${lDebug} || echo "...debug info: rm ${HTCconfig}/${HTCsparConfigFile}"
             rm ${HTCconfig}/${HTCsparConfigFile}
         fi
-        # ! ${lDebug} || echo "...debug info: gentlyStopJobs()"
-        # gentlyStopJobs
-        # ! ${lDebug} || echo "...debug info: waitForJobsToFinish()"
-        # waitForJobsToFinish
-        # ! ${lDebug} || echo "...debug info: condor_restart (killing remaining jobs)"
-        # condor_restart
+        ! ${lDebug} || echo "...debug info: gentlyStopJobs()"
+        gentlyStopJobs
+        ! ${lDebug} || echo "...debug info: waitForJobsToFinish()"
+        waitForJobsToFinish
+        ! ${lDebug} || echo "...debug info: condor_restart (killing remaining jobs)"
+        condor_restart
     fi
     
     echo "...done;"

--- a/admin/config/autoSwitch/switchHTC.sh
+++ b/admin/config/autoSwitch/switchHTC.sh
@@ -98,52 +98,46 @@ echoResources(){
     done
 }
 
-fullHTC() {
-    echo "call to fullHTC()"
+switchResources() {
+    echo "call to switchResources()"
+    lSwitch=false
     # steps:
     # 1. stop HTCondor node
-    # 2. move HTCondor .conf file sparing resources out of config dir
+    # 2. either of the two possibilities:
+    #    - restore HTCondor .conf file sparing resources in config dir
+    #    - move HTCondor .conf file sparing resources out of config dir
     # 3. gently stop jobs and wait for them to be over
     # 4. restart HTCondor on node (this will kill jobs still running)
-    if [ -e ${HTCconfig}/${HTCsparConfigFile} ] ; then
-        echo "... ${HTCsparConfigFile} present in ${HTCconfig}: let's proceed with switching..."
-        if ${lQuery} ; then
-            echo "...debug info: situation BEFORE switch:"
-            echoResources
+    if ${lSpare} ; then
+        if [ -e ${HTCset}/.config/${HTCsparConfigFile} ] ; then
+            echo "... ${HTCsparConfigFile} present in ${HTCset}/.config: moving all spared resources of the node back to HTCondor..."
+            lSwitch=true
+        else
+            echo "...no ${HTCsparConfigFile} in ${HTCset}/.config: aborting switch..."
         fi
-        ! ${lDebug} || echo "...debug info: condor_off -peaceful -startd"
-        condor_off -peaceful -startd
-        ! ${lDebug} || echo "...debug info: mv ${HTCconfig}/${HTCsparConfigFile} ${HTCset}/.config"
-        mv ${HTCconfig}/${HTCsparConfigFile} ${HTCset}/.config
-        ! ${lDebug} || echo "...debug info: gentlyStopJobs()"
-        gentlyStopJobs
-        ! ${lDebug} || echo "...debug info: waitForJobsToFinish()"
-        waitForJobsToFinish
-        ! ${lDebug} || echo "...debug info: condor_restart (killing remaining jobs)"
-        condor_restart
-    else
-        echo "...no ${HTCsparConfigFile} in ${HTCconfig}: aborting switch..."
+    elif ${lFull} ; then
+        if [ -e ${HTCconfig}/${HTCsparConfigFile} ] ; then
+            echo "... ${HTCsparConfigFile} present in ${HTCconfig}: sparing resources of the node from HTCondor..."
+            lSwitch=true
+        else
+            echo "...no ${HTCsparConfigFile} in ${HTCconfig}: aborting switch..."
+        fi
     fi
-    echo "...done;"
-}
 
-spareResources() {
-    echo "call to spareResources()"
-    # steps:
-    # 1. stop HTCondor node
-    # 2. restore HTCondor .conf file sparing resources in config dir
-    # 3. gently stop jobs and wait for them to be over
-    # 4. restart HTCondor on node (this will kill jobs still running)
-    if [ -e ${HTCset}/.config/${HTCsparConfigFile} ] ; then
-        echo "... ${HTCsparConfigFile} present in ${HTCset}/.config: let's proceed with switching..."
+    if ${lSwitch} ; then
         if ${lQuery} ; then
             echo "...debug info: situation BEFORE switch:"
             echoResources
         fi
         ! ${lDebug} || echo "...debug info: condor_off -peaceful -startd"
         condor_off -peaceful -startd
-        ! ${lDebug} || echo "...debug info: mv ${HTCset}/.config/${HTCsparConfigFile} ${HTCconfig}"
-        mv ${HTCset}/.config/${HTCsparConfigFile} ${HTCconfig}
+        if ${lSpare} ; then
+            ! ${lDebug} || echo "...debug info: mv ${HTCset}/.config/${HTCsparConfigFile} ${HTCconfig}"
+            mv ${HTCset}/.config/${HTCsparConfigFile} ${HTCconfig}
+        elif ${lFull} ; then
+            ! ${lDebug} || echo "...debug info: mv ${HTCconfig}/${HTCsparConfigFile} ${HTCset}/.config"
+            mv ${HTCconfig}/${HTCsparConfigFile} ${HTCset}/.config
+        fi
         ! ${lDebug} || echo "...debug info: gentlyStopJobs()"
         gentlyStopJobs
         ! ${lDebug} || echo "...debug info: waitForJobsToFinish()"
@@ -151,7 +145,6 @@ spareResources() {
         ! ${lDebug} || echo "...debug info: condor_restart (killing remaining jobs)"
         condor_restart
     else
-        echo "...no ${HTCsparConfigFile} in ${HTCset}/.config: aborting switch..."
     fi
     echo "...done;"
 }
@@ -240,15 +233,7 @@ fi
 # ==============================================================================
 
 if [ -e ${HTCset}/${HTCsparTrigger} ] ; then
-    if ${lFull} ; then
-        echo "moving all spared resources of the node back to HTCondor..."
-        fullHTC
-    elif ${lSpare} ; then
-        echo "sparing resources of the node from HTCondor..."
-        spareResources
-    else
-        echo "query resources:"
-    fi
+    switchResources
 else
     echo "...file ${HTCsparTrigger} NOT in folder ${HTCset}: aborting switch..."
 fi

--- a/admin/config/autoSwitch/switchHTC.sh
+++ b/admin/config/autoSwitch/switchHTC.sh
@@ -6,20 +6,23 @@
 # drwxr-xr-x 8 root root    4096 mar 31 09:48 ../
 # the condset linux group contains all people that can activate/deactivate
 #     the move of resources in/out of HTCondor
-# the HTCsparingConfigFile is the HTCondor config file sparing resources
+# the HTCsparConfigFile is the HTCondor config file sparing resources
 #     it is moved back and forth between the /home/condset and the HTCondor
 #     config folder
 
 HTCset=`dirname $0`
 HTCconfig=`condor_config_val LOCAL_CONFIG_DIR`
 HTCexecute=`condor_config_val EXECUTE`
-HTCsparingConfigFile="52-reduced-resources.conf"
-HTCtrigger="switch.me"
-lDebug=false
 # actions:
 lFull=false
 lSpare=false
 lQuery=true
+# options
+lDebug=false
+HTCsparConfigFile="52-spare-resources.conf"
+HTCsparTrigger=".switch.me"
+HTCSparCPUs=20 # []
+HTCSparRAM=65 # [GB]
 # script version
 scriptVer="0.1"
 
@@ -53,8 +56,15 @@ cat <<EOF
        -S  spare:      stops jobs, reset resources to a lower level and resumes
                          node activity.
 
-       actions:
-       -d  debug mode: debug output is on (off by default)
+       options:
+       -d  debug mode: debug output is on (default: ${lDebug})
+
+       -f  spare file: name of HTCondor config file describing resources to
+                         be spared (default: ${HTCsparConfigFile})
+
+       -n  spare CPUs: number of CPUs to spare (default: ${HTCSparCPUs})
+
+       -r  spare RAM:  RAM to spare (in GB - default: ${HTCSparRAM})
 EOF
 }
 
@@ -95,16 +105,16 @@ fullHTC() {
     # 2. move HTCondor .conf file sparing resources out of config dir
     # 3. gently stop jobs and wait for them to be over
     # 4. restart HTCondor on node (this will kill jobs still running)
-    if [ -e ${HTCconfig}/${HTCsparingConfigFile} ] ; then
-        echo "... ${HTCsparingConfigFile} present in ${HTCconfig}: let's proceed with switching..."
+    if [ -e ${HTCconfig}/${HTCsparConfigFile} ] ; then
+        echo "... ${HTCsparConfigFile} present in ${HTCconfig}: let's proceed with switching..."
         if ${lQuery} ; then
             echo "...debug info: situation BEFORE switch:"
             echoResources
         fi
         ! ${lDebug} || echo "...debug info: condor_off -peaceful -startd"
         condor_off -peaceful -startd
-        ! ${lDebug} || echo "...debug info: mv ${HTCconfig}/${HTCsparingConfigFile} ${HTCset}/.config"
-        mv ${HTCconfig}/${HTCsparingConfigFile} ${HTCset}/.config
+        ! ${lDebug} || echo "...debug info: mv ${HTCconfig}/${HTCsparConfigFile} ${HTCset}/.config"
+        mv ${HTCconfig}/${HTCsparConfigFile} ${HTCset}/.config
         ! ${lDebug} || echo "...debug info: gentlyStopJobs()"
         gentlyStopJobs
         ! ${lDebug} || echo "...debug info: waitForJobsToFinish()"
@@ -112,7 +122,7 @@ fullHTC() {
         ! ${lDebug} || echo "...debug info: condor_restart (killing remaining jobs)"
         condor_restart
     else
-        echo "...no ${HTCsparingConfigFile} in ${HTCconfig}: aborting switch..."
+        echo "...no ${HTCsparConfigFile} in ${HTCconfig}: aborting switch..."
     fi
     echo "...done;"
 }
@@ -124,16 +134,16 @@ spareResources() {
     # 2. restore HTCondor .conf file sparing resources in config dir
     # 3. gently stop jobs and wait for them to be over
     # 4. restart HTCondor on node (this will kill jobs still running)
-    if [ -e ${HTCset}/.config/${HTCsparingConfigFile} ] ; then
-        echo "... ${HTCsparingConfigFile} present in ${HTCset}/.config: let's proceed with switching..."
+    if [ -e ${HTCset}/.config/${HTCsparConfigFile} ] ; then
+        echo "... ${HTCsparConfigFile} present in ${HTCset}/.config: let's proceed with switching..."
         if ${lQuery} ; then
             echo "...debug info: situation BEFORE switch:"
             echoResources
         fi
         ! ${lDebug} || echo "...debug info: condor_off -peaceful -startd"
         condor_off -peaceful -startd
-        ! ${lDebug} || echo "...debug info: mv ${HTCset}/.config/${HTCsparingConfigFile} ${HTCconfig}"
-        mv ${HTCset}/.config/${HTCsparingConfigFile} ${HTCconfig}
+        ! ${lDebug} || echo "...debug info: mv ${HTCset}/.config/${HTCsparConfigFile} ${HTCconfig}"
+        mv ${HTCset}/.config/${HTCsparConfigFile} ${HTCconfig}
         ! ${lDebug} || echo "...debug info: gentlyStopJobs()"
         gentlyStopJobs
         ! ${lDebug} || echo "...debug info: waitForJobsToFinish()"
@@ -141,7 +151,7 @@ spareResources() {
         ! ${lDebug} || echo "...debug info: condor_restart (killing remaining jobs)"
         condor_restart
     else
-        echo "...no ${HTCsparingConfigFile} in ${HTCset}/.config: aborting switch..."
+        echo "...no ${HTCsparConfigFile} in ${HTCset}/.config: aborting switch..."
     fi
     echo "...done;"
 }
@@ -158,7 +168,7 @@ echo "`date +"[%Y-%m-%d %H:%M:%S]"` ==> ver ${scriptVer} <== $0 $*"
 # OPTIONs
 # ==============================================================================
 
-while getopts  ":dFQHS" opt ; do
+while getopts  ":dFQHn:r:S" opt ; do
     case $opt in
         d)
             lDebug=true
@@ -170,8 +180,14 @@ while getopts  ":dFQHS" opt ; do
             how_to_use
             die "" 0
             ;;
+        n)
+            HTCSparCPUs=$OPTARG
+            ;;
         Q)
             lQuery=true
+            ;;
+        r)
+            HTCSparRAM=$OPTARG
             ;;
         S)
             lSpare=true
@@ -223,7 +239,7 @@ fi
 # ACTUAL JOB
 # ==============================================================================
 
-if [ -e ${HTCset}/${HTCtrigger} ] ; then
+if [ -e ${HTCset}/${HTCsparTrigger} ] ; then
     if ${lFull} ; then
         echo "moving all spared resources of the node back to HTCondor..."
         fullHTC
@@ -234,7 +250,7 @@ if [ -e ${HTCset}/${HTCtrigger} ] ; then
         echo "query resources:"
     fi
 else
-    echo "...file ${HTCtrigger} NOT in folder ${HTCset}: aborting switch..."
+    echo "...file ${HTCsparTrigger} NOT in folder ${HTCset}: aborting switch..."
 fi
 
 if ${lQuery} ; then

--- a/admin/config/autoSwitch/switchHTC.sh
+++ b/admin/config/autoSwitch/switchHTC.sh
@@ -98,6 +98,16 @@ echoResources(){
     done
 }
 
+generateHTCspareFile(){
+    echo > ${HTCset}/.config/${HTCsparConfigFile} <<EOF
+# spare resources
+# - reserve ${HTCSparRAM} GB of RAM
+MEMORY = \$(DETECTED_MEMORY)-${HTCSparRAM}*1024
+# - reserve 20 threads
+NUM_CPUS = \$(NUM_CPUS)-${HTCSparCPUs}
+EOF
+}
+
 switchResources() {
     echo "call to switchResources()"
     lSwitch=false
@@ -109,15 +119,17 @@ switchResources() {
     # 3. gently stop jobs and wait for them to be over
     # 4. restart HTCondor on node (this will kill jobs still running)
     if ${lSpare} ; then
+        ! ${lDebug} || echo "...debug info: generateHTCspareFile()"
+        generateHTCspareFile
         if [ -e ${HTCset}/.config/${HTCsparConfigFile} ] ; then
-            echo "... ${HTCsparConfigFile} present in ${HTCset}/.config: moving all spared resources of the node back to HTCondor..."
+            echo "... ${HTCsparConfigFile} present in ${HTCset}/.config: sparing resources of the node from HTCondor..."
             lSwitch=true
         else
             echo "...no ${HTCsparConfigFile} in ${HTCset}/.config: aborting switch..."
         fi
     elif ${lFull} ; then
         if [ -e ${HTCconfig}/${HTCsparConfigFile} ] ; then
-            echo "... ${HTCsparConfigFile} present in ${HTCconfig}: sparing resources of the node from HTCondor..."
+            echo "... ${HTCsparConfigFile} present in ${HTCconfig}: moving all spared resources of the node back to HTCondor..."
             lSwitch=true
         else
             echo "...no ${HTCsparConfigFile} in ${HTCconfig}: aborting switch..."
@@ -129,23 +141,23 @@ switchResources() {
             echo "...debug info: situation BEFORE switch:"
             echoResources
         fi
-        ! ${lDebug} || echo "...debug info: condor_off -peaceful -startd"
-        condor_off -peaceful -startd
+        # ! ${lDebug} || echo "...debug info: condor_off -peaceful -startd"
+        # condor_off -peaceful -startd
         if ${lSpare} ; then
-            ! ${lDebug} || echo "...debug info: mv ${HTCset}/.config/${HTCsparConfigFile} ${HTCconfig}"
-            mv ${HTCset}/.config/${HTCsparConfigFile} ${HTCconfig}
+            ! ${lDebug} || echo "...debug info: mv ${HTCset}/${HTCsparConfigFile} ${HTCconfig}"
+            mv ${HTCset}/${HTCsparConfigFile} ${HTCconfig}
         elif ${lFull} ; then
-            ! ${lDebug} || echo "...debug info: mv ${HTCconfig}/${HTCsparConfigFile} ${HTCset}/.config"
-            mv ${HTCconfig}/${HTCsparConfigFile} ${HTCset}/.config
+            ! ${lDebug} || echo "...debug info: rm ${HTCconfig}/${HTCsparConfigFile}"
+            rm ${HTCconfig}/${HTCsparConfigFile}
         fi
-        ! ${lDebug} || echo "...debug info: gentlyStopJobs()"
-        gentlyStopJobs
-        ! ${lDebug} || echo "...debug info: waitForJobsToFinish()"
-        waitForJobsToFinish
-        ! ${lDebug} || echo "...debug info: condor_restart (killing remaining jobs)"
-        condor_restart
-    else
+        # ! ${lDebug} || echo "...debug info: gentlyStopJobs()"
+        # gentlyStopJobs
+        # ! ${lDebug} || echo "...debug info: waitForJobsToFinish()"
+        # waitForJobsToFinish
+        # ! ${lDebug} || echo "...debug info: condor_restart (killing remaining jobs)"
+        # condor_restart
     fi
+    
     echo "...done;"
 }
 

--- a/admin/config/luna-ws/52-reduced-resources.conf
+++ b/admin/config/luna-ws/52-reduced-resources.conf
@@ -1,5 +1,0 @@
-# spare resources
-# - reserve 64 GB of RAM
-MEMORY=$(DETECTED_MEMORY)-65*1024
-# - reserve 20 threads
-NUM_CPUS = $(NUM_CPUS)-20


### PR DESCRIPTION
In particular:
* resources are terminal line arguments to switching script;
* only one function for actual switch;
* HTCondor `.conf` file written on the fly by script.